### PR TITLE
Implement CRUD functionality for the SMS Model - Issue #7

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,3 +25,4 @@ Please describe the tests that you ran to verify your changes.
 - [ ] New and existing end-2-end tests pass locally with my changes
 
 #### ISSUE
+- [ISSUE]()

--- a/server/database/prisma/datamodel.prisma
+++ b/server/database/prisma/datamodel.prisma
@@ -4,13 +4,13 @@ type Contact {
     phoneNumber: String! @unique
     password: String!
     sentMessages: [SMS] @relation(name: "SentMessages", onDelete: CASCADE)
-    recievedMessages: [SMS] @relation(name: "RecievedMessages" , onDelete: CASCADE)
+    recievedMessages: [SMS] @relation(name: "RecievedMessages")
 }
 
 type SMS {
     id: ID! @id
     sender: Contact! @relation(name: "SentMessages")
-    reciever: Contact! @relation(name: "RecievedMessages")
+    reciever: Contact @relation(name: "RecievedMessages")
     message: String!
     status: String!
     createdAt: DateTime! @createdAt 

--- a/server/generated/prisma-client/index.d.ts
+++ b/server/generated/prisma-client/index.d.ts
@@ -176,7 +176,7 @@ export type ContactWhereUniqueInput = AtLeastOne<{
 }>;
 
 export interface SMSUpdateWithoutSenderDataInput {
-  reciever?: Maybe<ContactUpdateOneRequiredWithoutRecievedMessagesInput>;
+  reciever?: Maybe<ContactUpdateOneWithoutRecievedMessagesInput>;
   message?: Maybe<String>;
   status?: Maybe<String>;
 }
@@ -249,10 +249,12 @@ export interface ContactWhereInput {
   NOT?: Maybe<ContactWhereInput[] | ContactWhereInput>;
 }
 
-export interface ContactUpdateOneRequiredWithoutRecievedMessagesInput {
+export interface ContactUpdateOneWithoutRecievedMessagesInput {
   create?: Maybe<ContactCreateWithoutRecievedMessagesInput>;
   update?: Maybe<ContactUpdateWithoutRecievedMessagesDataInput>;
   upsert?: Maybe<ContactUpsertWithoutRecievedMessagesInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
   connect?: Maybe<ContactWhereUniqueInput>;
 }
 
@@ -383,7 +385,7 @@ export interface ContactCreateWithoutSentMessagesInput {
 
 export interface SMSUpdateInput {
   sender?: Maybe<ContactUpdateOneRequiredWithoutSentMessagesInput>;
-  reciever?: Maybe<ContactUpdateOneRequiredWithoutRecievedMessagesInput>;
+  reciever?: Maybe<ContactUpdateOneWithoutRecievedMessagesInput>;
   message?: Maybe<String>;
   status?: Maybe<String>;
 }
@@ -472,7 +474,7 @@ export interface SMSUpdateWithWhereUniqueWithoutRecieverInput {
 export interface SMSCreateInput {
   id?: Maybe<ID_Input>;
   sender: ContactCreateOneWithoutSentMessagesInput;
-  reciever: ContactCreateOneWithoutRecievedMessagesInput;
+  reciever?: Maybe<ContactCreateOneWithoutRecievedMessagesInput>;
   message: String;
   status: String;
 }
@@ -589,7 +591,7 @@ export interface ContactCreateWithoutRecievedMessagesInput {
 
 export interface SMSCreateWithoutSenderInput {
   id?: Maybe<ID_Input>;
-  reciever: ContactCreateOneWithoutRecievedMessagesInput;
+  reciever?: Maybe<ContactCreateOneWithoutRecievedMessagesInput>;
   message: String;
   status: String;
 }

--- a/server/generated/prisma-client/prisma-schema.js
+++ b/server/generated/prisma-client/prisma-schema.js
@@ -120,17 +120,19 @@ input ContactUpdateManyMutationInput {
   password: String
 }
 
-input ContactUpdateOneRequiredWithoutRecievedMessagesInput {
-  create: ContactCreateWithoutRecievedMessagesInput
-  update: ContactUpdateWithoutRecievedMessagesDataInput
-  upsert: ContactUpsertWithoutRecievedMessagesInput
-  connect: ContactWhereUniqueInput
-}
-
 input ContactUpdateOneRequiredWithoutSentMessagesInput {
   create: ContactCreateWithoutSentMessagesInput
   update: ContactUpdateWithoutSentMessagesDataInput
   upsert: ContactUpsertWithoutSentMessagesInput
+  connect: ContactWhereUniqueInput
+}
+
+input ContactUpdateOneWithoutRecievedMessagesInput {
+  create: ContactCreateWithoutRecievedMessagesInput
+  update: ContactUpdateWithoutRecievedMessagesDataInput
+  upsert: ContactUpsertWithoutRecievedMessagesInput
+  delete: Boolean
+  disconnect: Boolean
   connect: ContactWhereUniqueInput
 }
 
@@ -280,7 +282,7 @@ type Query {
 type SMS {
   id: ID!
   sender: Contact!
-  reciever: Contact!
+  reciever: Contact
   message: String!
   status: String!
   createdAt: DateTime!
@@ -295,7 +297,7 @@ type SMSConnection {
 input SMSCreateInput {
   id: ID
   sender: ContactCreateOneWithoutSentMessagesInput!
-  reciever: ContactCreateOneWithoutRecievedMessagesInput!
+  reciever: ContactCreateOneWithoutRecievedMessagesInput
   message: String!
   status: String!
 }
@@ -319,7 +321,7 @@ input SMSCreateWithoutRecieverInput {
 
 input SMSCreateWithoutSenderInput {
   id: ID
-  reciever: ContactCreateOneWithoutRecievedMessagesInput!
+  reciever: ContactCreateOneWithoutRecievedMessagesInput
   message: String!
   status: String!
 }
@@ -423,7 +425,7 @@ input SMSSubscriptionWhereInput {
 
 input SMSUpdateInput {
   sender: ContactUpdateOneRequiredWithoutSentMessagesInput
-  reciever: ContactUpdateOneRequiredWithoutRecievedMessagesInput
+  reciever: ContactUpdateOneWithoutRecievedMessagesInput
   message: String
   status: String
 }
@@ -474,7 +476,7 @@ input SMSUpdateWithoutRecieverDataInput {
 }
 
 input SMSUpdateWithoutSenderDataInput {
-  reciever: ContactUpdateOneRequiredWithoutRecievedMessagesInput
+  reciever: ContactUpdateOneWithoutRecievedMessagesInput
   message: String
   status: String
 }

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,7 @@ import { merge } from 'lodash';
 import { prisma } from './generated/prisma-client';
 import { typeDef as Auth, resolvers as authResolvers } from './schemas/Auth';
 import { typeDef as Contact, resolvers as contactResolvers, middleware as contactMiddleware } from './schemas/Contact';
-import { typeDef as Sms } from './schemas/Sms';
+import { typeDef as Sms, resolvers as smsResolvers, middleware as smsMiddleware } from './schemas/Sms';
 
 
 const Query = `
@@ -22,11 +22,11 @@ const resolvers = {
   },
 };
 
-const middlewares = [contactMiddleware];
+const middlewares = [contactMiddleware, smsMiddleware];
 
 const server = new GraphQLServer({
   typeDefs: [Query, Mutation, Auth, Contact, Sms],
-  resolvers: merge(resolvers, authResolvers, contactResolvers),
+  resolvers: merge(resolvers, authResolvers, contactResolvers, smsResolvers),
   context: request => ({
     ...request,
     prisma,

--- a/server/schemas/Auth.js
+++ b/server/schemas/Auth.js
@@ -20,7 +20,10 @@ export const resolvers = {
     signup: async (parent, args, context) => {
       const password = await bcrypt.hash(args.password, 10);
       const user = await context.prisma.createContact({ ...args, password });
-      const token = jwt.sign({ userId: user.id }, APP_SECRET, { expiresIn: '3h' });
+      const token = jwt.sign({
+        userId: user.id,
+        phoneNumber: user.phoneNumber,
+      }, APP_SECRET, { expiresIn: '3h' });
 
       return {
         token,
@@ -39,7 +42,10 @@ export const resolvers = {
         throw new Error('Invalid Password');
       }
 
-      const token = jwt.sign({ userId: user.id }, APP_SECRET, { expiresIn: '3h' });
+      const token = jwt.sign({
+        userId: user.id,
+        phoneNumber: user.phoneNumber, 
+      }, APP_SECRET, { expiresIn: '3h' });
 
       return {
         token,

--- a/server/schemas/Contact.js
+++ b/server/schemas/Contact.js
@@ -6,14 +6,14 @@ extend type Query {
     contact(phoneNumber: String!): Contact
 }
 
-extend type Mutation {
-    updateContact(id: ID!, name: String, phoneNumber: String): Contact
-    deleteContact(phoneNumber: String!): Contact
-}
-
 type ContactList {
     contacts: [Contact!]!
     count: Int!
+}
+
+extend type Mutation {
+    updateContact(id: ID!, name: String, phoneNumber: String): Contact
+    deleteContact(phoneNumber: String!): Contact
 }
 
 type Contact {
@@ -32,8 +32,8 @@ export const resolvers = {
       const count = await context.prisma.contactsConnection().aggregate().count();
 
       return {
-        contacts,
         count,
+        contacts,
       };
     },
     contact: (parent, args, context) => context.prisma.contact({
@@ -58,6 +58,22 @@ export const resolvers = {
     },
     deleteContact: (parent, args, context) => context.prisma.deleteContact({
       phoneNumber: args.phoneNumber,
+    }),
+  },
+  Contact: {
+    sentMessages: async (parent, args, context) => context.prisma.sMses({
+      where: {
+        sender: await context.prisma.contact({
+          id: parent.id,
+        }),
+      },
+    }),
+    recievedMessages: async (parent, args, context) => context.prisma.sMses({
+      where: {
+        reciever: await context.prisma.contact({
+          id: parent.id,
+        }),
+      },
     }),
   },
 };

--- a/server/schemas/Sms.js
+++ b/server/schemas/Sms.js
@@ -1,6 +1,21 @@
-import gql from 'graphql-tag';
+import authenticateUser from '../utils/middleware/authMiddleware';
 
-export const typeDef = gql`
+export const typeDef = `
+extend type Query {
+    allSMS: SMSList
+    sms(id: ID!): SMS
+}
+
+type SMSList {
+    smses: [SMS!]!
+    count: Int!
+}
+
+extend type Mutation {
+    createSMS(reciever: String!, message: String!): SMS
+    deleteSMS(id: ID!): SMS
+}
+
 type SMS {
     id: ID!
     sender: Contact
@@ -9,4 +24,47 @@ type SMS {
     status: String!
 }`;
 
-export const resolvers = {};
+export const resolvers = {
+  Query: {
+    allSMS: async (parent, args, context) => {
+      const smses = await context.prisma.sMses();
+      const count = await context.prisma.sMsesConnection().aggregate().count();
+
+      return {
+        count,
+        smses,
+      };
+    },
+    sms: (parent, args, context) => context.prisma.sMS({ id: args.id }),
+  },
+  Mutation: {
+    createSMS: (parent, args, context) => context.prisma.createSMS({
+      reciever: { connect: { phoneNumber: args.reciever } },
+      sender: { connect: { phoneNumber: context.userInfo.phoneNumber } },
+      message: args.message,
+      status: 'SENT',
+    }),
+    deleteSMS: (parent, args, context) => context.prisma.deleteSMS({
+      id: args.id,
+    }),
+  },
+  SMS: {
+    sender: (parent, args, context) => context.prisma.sMS({
+      id: parent.id,
+    }).sender(),
+
+    reciever: (parent, args, context) => context.prisma.sMS({
+      id: parent.id,
+    }).reciever(),
+  },
+};
+export const middleware = {
+  Query: {
+    allSMS: authenticateUser,
+    sms: authenticateUser,
+  },
+  Mutation: {
+    deleteSMS: authenticateUser,
+    createSMS: authenticateUser,
+  },
+};

--- a/server/utils/middleware/authMiddleware.js
+++ b/server/utils/middleware/authMiddleware.js
@@ -8,8 +8,11 @@ const authenticateUser = async (resolve, parent, args, context, info) => {
 
   if (Authorization) {
     const token = Authorization.replace('Bearer ', '');
-    const { userId } = jwt.verify(token, APP_SECRET);
-    context.userId = userId;
+    const { userId, phoneNumber } = jwt.verify(token, APP_SECRET);
+    context.userInfo = {
+      userId,
+      phoneNumber,
+    };
     const result = await resolve(parent, args, context, info);
     return result;
   }


### PR DESCRIPTION
#### Description
This PR extends the functionalities of the current GraphQL API to include the full CRUD functionalities for an SMS (Read an SMS, delete an SMS and update an SMS)
#### Type of change

Please delete options that are not relevant

- [x] New feature (non-breaking change which add a functionality)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

#### ISSUE
- [ISSUE #7](https://github.com/JCanaks/ConnectMS/issues/7)
